### PR TITLE
Fixes first mentioned unit name at the API example

### DIFF
--- a/content/en/LAYERS.md
+++ b/content/en/LAYERS.md
@@ -14,7 +14,7 @@ Let's introduce two basic concepts:
 
 In order to provide the best developer experience for rapid API development, Metarhia offers auto-routing for API requests and webhooks. There's no need to manually add routes; all calls made over supported protocols (HTTP, HTTPS, WS, WSS) will be automatically directed to `endpoints` based on file system paths. The format of request and response payloads is defined by the [Metacom protocol](https://github.com/metarhia/Contracts/blob/master/doc/Metacom.md) specification and implemented in the npm package [Metacom](https://www.npmjs.com/package/metacom). Metarhia supports automatic request concurrency control, including request execution timeouts and an execution queue with both timeout and queue size limitations. API calls can have contracts (schemas) for automatic input and output data validation. The application server provides isolation for code execution; for more details, see [isolation](https://github.com/metarhia/Docs/blob/main/content/en/SERVER.md#context-isolation). The application server also supports various API styles: RPC over AJAX, RPC over Websocket, REST, and webhooks.
 
-To create API endpoint put file `getCity.js` to folder `application/api/geo` with following source:
+To create API endpoint put file `getCity.js` to folder `application/api/example` with following source:
 
 ```js
 async ({ cityId }) => {
@@ -25,7 +25,7 @@ async ({ cityId }) => {
 
 - Now you can start the server: `node server.js`
 - Open the browser and DevTools (F12)
-- On the `Console` tab and write: `await api.geo.getCity({ cityId: 1 });`
+- On the `Console` tab and write: `await api.example.getCity({ cityId: 1 });`
 - You will get: `metacom.js:18 Uncaught Error: Forbidden`
 - You need either to deploy a database for the auth subsystem or remove restrictions to access this method
 - Add `access: 'public'` so endpoint will look like this:


### PR DESCRIPTION
Section [API layer: units and endpoints](https://github.com/metarhia/Docs/blob/main/content/en/LAYERS.md#api) contains proposal to try creation of endpoint step by step.   First two mentions  provides `geo` as a name of the unit to create endpoint in:
- https://github.com/metarhia/Docs/blob/3f3b82e5430687fa48b1b7b003a4eabe416051ae/content/en/LAYERS.md?plain=1#L17
- https://github.com/metarhia/Docs/blob/3f3b82e5430687fa48b1b7b003a4eabe416051ae/content/en/LAYERS.md?plain=1#L28

That proposal will not work as expected for those trying to implement that based on [Example](https://github.com/metarhia/Example) project because:
1. The `geo` unit by default not present in introspection query (there is `
["auth", "console", "example", "files"]`), so it wouldn't available from DevTools console even with public flag.
2. Example project already has `geo` unit implemented as the file [geo.1.js](https://github.com/metarhia/Example/blob/master/application/api/geo.1.js) that contains example of plugin based API unit. That's why even if we put the `geo` in introspection query — the step by step manual might not work as expected by reader.

Third and later mentions of unit in that same example already uses name `example` :
- https://github.com/metarhia/Docs/blob/3f3b82e5430687fa48b1b7b003a4eabe416051ae/content/en/LAYERS.md?plain=1#L44
- https://github.com/metarhia/Docs/blob/3f3b82e5430687fa48b1b7b003a4eabe416051ae/content/en/LAYERS.md?plain=1#L69

The PR changed first two mentions of unit name in example from `geo` to `example`, so the step by step guide becomes consistent.