### PR TITLE
Extends domain logic section in LAYERS with usage example

### DIFF
--- a/content/en/LAYERS.md
+++ b/content/en/LAYERS.md
@@ -220,6 +220,15 @@ There is a special place for domain logic and application state: `application/do
 });
 ```
 
+The methods and public properties of the module will be available from another application layers through the `domain.chat` namespace. For example it made possible a thin API endpoint `application/api/chat/send.js` that will deliver a message from one chat room participant to all others without handling a state by itself:
+
+```js
+(async ({ room, message }) => {
+  domain.chat.send(room, message);
+  return true;
+});
+```
+
 ## Libraries
 
 Auxiliary code that is not related to subject domain, but we don't want to create or import separete dependencies for it, can be placed in: `application/lib`. For example:


### PR DESCRIPTION
This PR is a proposal, not a fix.

It seems useful in my opinion to extend the [Domain logic layer: state and procedures](https://github.com/metarhia/Docs/blob/main/content/en/LAYERS.md#domain-logic) section with small usage example of mentioned module.  The availability of the `domain` layer modules has been already mentioned at [Module format](https://github.com/metarhia/Docs/blob/main/content/en/START.md#module-format). However it might be more clear for newbies , to place the usage example directly into "Domain logic" section (the same way as in the API layer section).

This PR uses `application/api/chat/send.js` as an example.