### PR TITLE
Fix typo

### DIFF
--- a/content/en/LAYERS.md
+++ b/content/en/LAYERS.md
@@ -222,7 +222,7 @@ There is a special place for domain logic and application state: `application/do
 
 ## Libraries
 
-Auxiliary code that is not related to subject domain, but we don't want to create or import separete dependencies for it, can be placed in: `application/lib`. For example:
+Auxiliary code that is not related to subject domain, but we don't want to create or import separate dependencies for it, can be placed in: `application/lib`. For example:
 
 ```js
 ({


### PR DESCRIPTION
Fixes tiny typo in the "Libraries" section of the LAYERS page.