### PR TITLE
Fix direct PostgreSQL access examples

### DIFF
--- a/content/en/LAYERS.md
+++ b/content/en/LAYERS.md
@@ -291,14 +291,14 @@ You can initialize database connection on application start from `application/db
 
 ```js
 async () => {
-  db.geo = new npm.pg.Pool(config.database);
+  db.geo.pg = new npm.pg.Pool(config.database);
 };
 ```
 
 After that you can access db driver from anywhere like:
 
 ```js
-const res = await db.geo.query('SELECT * from CITIES where ID = $1', [25]);
+const res = await db.geo.pg.query('SELECT * from CITIES where ID = $1', [25]);
 console.log(res.rows[0]);
 ```
 

--- a/content/en/LAYERS.md
+++ b/content/en/LAYERS.md
@@ -287,21 +287,21 @@ This will send HTTP GET request to `http://worldtimeapi.org/api/timezone/Europe/
 
 ## Data access
 
-You can initialize database connection on application start from `application/db` for example putting `start` hook to `application/db/pg/start.js`:
+You can initialize database connection on application start from `application/db` for example putting `start` hook to `application/db/geo/start.js`:
 
 ```js
 async () => {
-  db.geo.pg = new Pool(config.database);
+  db.geo = new npm.pg.Pool(config.database);
 };
 ```
 
 After that you can access db driver from anywhere like:
 
 ```js
-const res = await db.geo.pg.query('SELECT * from CITIES where ID = $1', [25]);
+const res = await db.geo.query('SELECT * from CITIES where ID = $1', [25]);
 console.log(res.rows[0]);
 ```
 
-More examples in: [/content/en/DATA.md](/content/en/DATA.md)
+More details with examples in: [/content/en/DATA.md](/content/en/DATA.md)
 
 [👉 Back to contents](/) | [🚀 Getting started](/content/en/START.md) | [🗃️ Data modeling, storage, and access](/content/en/DATA.md) | [🧩 Application server features](/content/en/SERVER.md)


### PR DESCRIPTION
There is a few issues with example in the section [Data access layer](https://github.com/metarhia/Docs/blob/main/content/en/LAYERS.md#data-access) and some in DATA page section [PostgreSQL driver](https://github.com/metarhia/Docs/blob/main/content/en/DATA.md#postgresql) as well . 

It seems that "Data access layer" section goal is to provide smallest quickest mention of the layer and forward reader to the detailed specialized page. However there is some inaccuracy that might confuse if someone tries to reproduce the guidance immediately:

1. https://github.com/metarhia/Docs/blob/d4789cd85052970e751b6641a5df644a5c32e92d/content/en/LAYERS.md?plain=1#L290 If the reader trying Metarhia with "Example" repository there is already existed `application/db/pg/start.js` hook that contains establishing Metasql.Database instead of direct pg connection.
2. https://github.com/metarhia/Docs/blob/d4789cd85052970e751b6641a5df644a5c32e92d/content/en/LAYERS.md?plain=1#L294 
    2.1 There is no available `Pool` in the context of all application layers, so this will broke app startup with `Failed to execute method: Pool is not defined ReferenceError: Pool is not defined`.  There is already full namespaced version `npm.pg.Pool` in the "PostgreSQL driver" section examples.
    2.2 It's impossible to directly set inner property `pg` of the not yet existed object `geo` (if the code was placed in `pg/start.js` instead of `geo/start.js`), so this will also broke the app startup with `Failed to execute method: Cannot set properties of undefined (setting 'pg') TypeError: Cannot set properties of undefined (setting 'pg')`. 
