### PR TITLE
Add missed lang note into code block of Testing section

### DIFF
--- a/content/en/SERVER.md
+++ b/content/en/SERVER.md
@@ -116,7 +116,7 @@ Examples for `every` field syntax:
 
 Metarhia uses node.js native test runner to execute tests. You can add tests for `application/domain/chat.js` in `application/domain/chat.test.js`:
 
-```
+```js
 ({
   name: 'Chat test',
 


### PR DESCRIPTION
Small fix to enable syntax highlight for JS code block inside [Testing](https://github.com/metarhia/Docs/blob/main/content/en/SERVER.md#testing) section at SERVER page.