### PR TITLE
Enhance data layer explanation

### DIFF
--- a/content/en/LAYERS.md
+++ b/content/en/LAYERS.md
@@ -311,6 +311,8 @@ const res = await db.geo.pg.query('SELECT * from CITIES where ID = $1', [25]);
 console.log(res.rows[0]);
 ```
 
+Are you notice a `Pool` assignment to `db.geo.pg` instead of just `db.geo` in the example? That's not strict requirement but rather convenient recommendation to assign initialized database's driver into sub-property of related namespace because data access layer isn't only for connection initialization. Think about this layer as a place for wide range of practical possibilities to organize efficient data access. You may start from just DB driver, but later you'll add some query builder beside or extend namespace with your own modules containing specific data management helpers on top of DB driver. Proposed layer organization will help to grow your application without breaking changes.     
+
 More details with examples in: [/content/en/DATA.md](/content/en/DATA.md)
 
 [👉 Back to contents](/) | [🚀 Getting started](/content/en/START.md) | [🗃️ Data modeling, storage, and access](/content/en/DATA.md) | [🧩 Application server features](/content/en/SERVER.md)


### PR DESCRIPTION
This PR will add one paragraph into [Data access layer](https://github.com/metarhia/Docs/blob/main/content/en/LAYERS.md#data-access) section on LAYERS page. It contains explanation that `db` namespace isn't only for database connection initialization through the start hook. So it becomes more obvious for reader that he might place own modules there builded on top of database driver. 

Please review @tshemsedinov . Am I right with this explanation?