### PR TITLE
Correction of scheduler timeout setting description

### DIFF
--- a/content/en/START.md
+++ b/content/en/START.md
@@ -101,7 +101,7 @@ File `config/server.js`:
   scheduler: {
     concurrency: 10,   // Task scheduler concurrency
     size: 2000,        // Scheduler queue size
-    timeout: 3000,     // Task execution timeout
+    timeout: 3000,     // Tasks queue timeout
   },
   workers: {
     pool: 0,           // Workers pool size


### PR DESCRIPTION
Scheduler settings in `config/server.js` used by Impress  https://github.com/metarhia/impress/blob/1fd89f6ef109f2bb84267e0b40af51a90b804479/impress.js#L160-L161 `Planner`    for creating `Semaphore`s per task topic https://github.com/metarhia/impress/blob/1fd89f6ef109f2bb84267e0b40af51a90b804479/lib/planner.js#L140-L148 

`Semaphore`'s timeout can't limit task execution time because it's purpose to limit time awaiting in a queue.