### PR TITLE
Correct example of exception override

### DIFF
--- a/content/en/LAYERS.md
+++ b/content/en/LAYERS.md
@@ -160,10 +160,10 @@ Example with raise exception:
 
 Result with exception (metacom packet): `{"callback":1,"error":{"message":"Internal Server Error","code":500}}`
 
-How to override error codes: `throw new Error('Method is not implemented', 404);`
-This will take error message from code: `{"callback":1,"error":{"message":"Not found","code":404}}`
+How to override error codes: `throw new Error('Not found', 404);`
+This will take error message and code as is: `{"callback":1,"error":{"message":"Not found","code":404}}`
 
-If you specify unknown code like this: `throw new Error('Method is not implemented', 12345);` this will generate: `"Internal Server Error"` with `"code":500`.
+If you specify unknown code like this `throw new Error('Method is not implemented', 12345);`, this will generate: `"Internal Server Error"` with `"code":500`.
 
 ## Network
 


### PR DESCRIPTION
Closes: https://github.com/metarhia/Docs/issues/21
Refs: https://github.com/metarhia/metacom/pull/486

When the PR https://github.com/metarhia/metacom/pull/486 will be landed — sentence about conversion of code `12345` and message to `"Internal Server Error"` with `"code":500` becomes true. However conversion of exception message with code 404 (_and all below known 599 range_) still not happening automatically and there is no need to change that behavior. So this PR will correct example in [Error-handling guidelines](https://github.com/metarhia/Docs/blob/main/content/en/LAYERS.md#error-handling-guidelines) section at LAYERS page.